### PR TITLE
Fix pylint warnings

### DIFF
--- a/main_application.py
+++ b/main_application.py
@@ -1,4 +1,4 @@
-"""Main applicatoin that demonstrates the functionality of
+"""Main application that demonstrates the functionality of
 the dynamic plugins and the PluginCollection class
 """
 

--- a/plugins/double/double_negative.py
+++ b/plugins/double/double_negative.py
@@ -1,8 +1,13 @@
-import plugin_collection
+"""Negative double function
+"""
 
-class DoubleNegative(plugin_collection.Plugin):
+from plugin_collection import Plugin
+
+class DoubleNegative(Plugin):
     """This plugin will just multiply the argument with the value -2
     """
+    # pylint: disable=too-few-public-methods
+
     def __init__(self):
         super().__init__()
         self.description = 'Negative double function'

--- a/plugins/double/double_positive.py
+++ b/plugins/double/double_positive.py
@@ -1,8 +1,13 @@
+"""Double function
+"""
+
 from plugin_collection import Plugin
 
 class DoublePositive(Plugin):
     """This plugin will just multiply the argument with the value 2
     """
+    # pylint: disable=too-few-public-methods
+
     def __init__(self):
         super().__init__()
         self.description = 'Double function'

--- a/plugins/identity.py
+++ b/plugins/identity.py
@@ -1,8 +1,13 @@
-import plugin_collection 
+"""Identity function
+"""
 
-class Identity(plugin_collection.Plugin):
+from plugin_collection import Plugin
+
+class Identity(Plugin):
     """This plugin is just the identity function: it returns the argument
     """
+    # pylint: disable=too-few-public-methods
+
     def __init__(self):
         super().__init__()
         self.description = 'Identity function'


### PR DESCRIPTION
- fix unnecessary use of a comprehension
- wrap too long lines
- add missing module docstrings
- remove object from class declarations
- use python naming conventions
- disable "too-few-public-methods" warning